### PR TITLE
Support v2:customExts, UI tweaks for policies

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -32,9 +32,6 @@ launch-screen@2.0.1
 logging@1.3.6
 meteor@2.1.1
 meteor-base@1.5.2
-meteortesting:browser-tests@1.8.0
-meteortesting:mocha@3.3.0
-meteortesting:mocha-core@8.2.0
 minifier-css@2.0.1
 minifier-js@3.0.2
 minimongo@2.0.2

--- a/imports/api/moderation/policies/publications.ts
+++ b/imports/api/moderation/policies/publications.ts
@@ -7,7 +7,7 @@ Meteor.publish("moderation_policies", function () {
         fields: {
             type: 1,
             action: 1,
-            fields: 1
+            customField: 1
         }
     });
 });

--- a/imports/types/ModerationPolicy.ts
+++ b/imports/types/ModerationPolicy.ts
@@ -5,8 +5,9 @@ export enum ModerationAction {
 }
 
 export type ModerationPolicy = {
-    createdAt: Date;
-    type: string; // e.g., 'txt', 'image', etc.
-    action: ModerationAction;
-    fields: string; // e.g., ['msg', 'caption']
+  createdAt: Date;
+  type: string; // e.g., 'txt', 'image', etc.
+  action: ModerationAction;
+  customField: string;
+  updatedAt: Date;
 }

--- a/imports/ui/layout/MainLayout.tsx
+++ b/imports/ui/layout/MainLayout.tsx
@@ -13,7 +13,7 @@ export default function MainLayout() {
     return (
         <div className="page">
             <aside
-                className="navbar navbar-vertical navbar-expand-sm position-absolute"
+                className="navbar navbar-vertical navbar-expand-sm position-absolute vh-100"
                 data-bs-theme="dark"
             >
                 <div className="container-fluid">
@@ -72,13 +72,13 @@ export default function MainLayout() {
             </aside>
             <div className="page-wrapper">
                 <div className="page-header d-print-none">
-                    <div className="container-xl">
+                    {/* <div className="container-xl">
                         <div className="row g-2 align-items-center">
                             <div className="col">
                                 <h2 className="page-title">Vertical layout</h2>
                             </div>
                         </div>
-                    </div>
+                    </div> */}
                 </div>
                 <div className="page-body">
                     <div className="container-xl">

--- a/imports/ui/pages/Policies.tsx
+++ b/imports/ui/pages/Policies.tsx
@@ -82,7 +82,7 @@ export default function Policies() {
             <thead className="table-light">
               <tr>
                 <th style={{ width: "160px" }}>Message Type</th>
-                <th style={{ width: "220px" }}>Action</th>
+                <th style={{ width: "230px" }}>Action</th>
                 <th>Custom Moderation Field</th>
                 <th style={{ width: "100px" }}></th>
               </tr>

--- a/imports/ui/pages/Policies.tsx
+++ b/imports/ui/pages/Policies.tsx
@@ -21,7 +21,9 @@ export default function Policies() {
           setPolicies(res);
           const draft: Record<string, ModerationPolicy> = {};
           res.forEach((p) => {
-            draft[p.type] = p;
+            draft[p.type] = {
+              ...p,
+              customField: p.customField || "",};
           });
           setDraftPolicies(draft);
         }
@@ -45,10 +47,10 @@ export default function Policies() {
     if (draft.action) {
       Meteor.call("moderation.setPolicy", { type, action: draft.action });
     }
-    if (type === "custom" && draft.fields) {
-      Meteor.call("moderation.setPolicyFields", {
+    if (type === "custom" && draft.customField) {
+      Meteor.call("moderation.setPolicyCustomField", {
         type,
-        fields: [draft.fields],
+        customField: draft.customField,
       });
     }
     setPolicies((prev) => {
@@ -56,8 +58,9 @@ export default function Policies() {
       const updatedPolicy: ModerationPolicy = {
         type,
         action: draft.action,
-        fields: draft.fields,
+        customField: draft.customField,
         createdAt: new Date(),
+        updatedAt: new Date(),
       };
 
       if (existing) {
@@ -80,7 +83,7 @@ export default function Policies() {
               <tr>
                 <th style={{ width: "160px" }}>Message Type</th>
                 <th style={{ width: "220px" }}>Action</th>
-                <th>Audit Field (for 'custom' type only)</th>
+                <th>Custom Moderation Field</th>
                 <th style={{ width: "100px" }}></th>
               </tr>
             </thead>
@@ -113,10 +116,10 @@ export default function Policies() {
                         <input
                           type="text"
                           className="form-control form-control-sm"
-                          placeholder="e.g. v2:customExts.msg"
-                          value={draft.fields || ""}
+                          placeholder="Enter your custom field name"
+                          value={draft.customField || ""}
                           onChange={(e) =>
-                            handleDraftChange(type, "field", e.target.value)
+                            handleDraftChange(type, "customField", e.target.value)
                           }
                         />
                       )}

--- a/server/utils/objectUtils.test.ts
+++ b/server/utils/objectUtils.test.ts
@@ -1,50 +1,49 @@
-import { getValueByPath, setValueByPath } from "./objectUtils";
+import { getValueByField, setValueByField } from "./objectUtils";
 import { expect } from "chai";
 
-describe('getValueByPath', () => {
-    const obj = {
-        msg: {
-            content: 'hello',
-            metadata: { lang: 'en' },
+describe('getValueByField & setValueByField', () => {
+    const sample = {
+        user: { id: 'u1', name: 'Carlson' },
+        message: {
+            content: 'hi',
+            metadata: {
+                customField: 'value',
+            },
         },
     };
 
-    it('returns top-level field', () => {
-        expect(getValueByPath(obj, 'msg.content')).to.equal('hello');
+    it('should get a top-level nested field by name', () => {
+        const value = getValueByField(sample, 'name');
+        expect(value).to.equal('Carlson');
     });
 
-    it('returns nested field', () => {
-        expect(getValueByPath(obj, 'msg.metadata.lang')).to.equal('en');
+    it('should get a deep nested field by name', () => {
+        const value = getValueByField(sample, 'customField');
+        expect(value).to.equal('value');
     });
 
-    it('returns undefined for non-existent path', () => {
-        expect(getValueByPath(obj, 'msg.foo')).to.be.undefined;
+    it('should return undefined if field does not exist', () => {
+        const value = getValueByField(sample, 'notExist');
+        expect(value).to.be.undefined;
     });
 
-    it('returns object for empty path', () => {
-        expect(getValueByPath(obj, '')).to.equal(obj);
-    });
-});
-
-describe('setValueByPath', () => {
-    const obj = {
-        msg: {
-            content: 'hello',
-            metadata: { lang: 'en' },
-        },
-    };
-
-    it('sets top-level field', () => {
-        setValueByPath(obj, 'msg.content', 'world');
-        expect(obj.msg.content).to.equal('world');
+    it('should set a top-level nested field by name', () => {
+        const copy = JSON.parse(JSON.stringify(sample));
+        const success = setValueByField(copy, 'name', 'Ellie');
+        expect(success).to.be.true;
+        expect(copy.user.name).to.equal('Ellie');
     });
 
-    it('sets nested field', () => {
-        setValueByPath(obj, 'msg.metadata.lang', 'fr');
-        expect(obj.msg.metadata.lang).to.equal('fr');
+    it('should set a deep nested field by name', () => {
+        const copy = JSON.parse(JSON.stringify(sample));
+        const success = setValueByField(copy, 'customField', 'updated');
+        expect(success).to.be.true;
+        expect(copy.message.metadata.customField).to.equal('updated');
     });
 
-    it('does not throw for non-existent path when setting value', () => {
-        expect(() => setValueByPath(obj, 'non.existent.path', 'test')).to.not.throw();
+    it('should return false if field does not exist when setting', () => {
+        const copy = JSON.parse(JSON.stringify(sample));
+        const success = setValueByField(copy, 'unknownField', 'something');
+        expect(success).to.be.false;
     });
 });

--- a/server/webhook/webhook.ts
+++ b/server/webhook/webhook.ts
@@ -3,7 +3,7 @@ import bodyParser from 'body-parser';
 import { ModerationPolicies } from '/imports/api/moderation/policies/collection';
 import { hasBlockedWords, replaceBlockedWords } from '/imports/api/blocklist/service';
 import { logDev } from '/imports/utils/logger';
-import { getValueByPath, setValueByPath } from '../utils/objectUtils';
+import { getValueByField, setValueByField } from '../utils/objectUtils';
 
 const jsonParser = bodyParser.json();
 
@@ -33,7 +33,7 @@ WebApp.handlers.use('/webhook/moderate', jsonParser, async (req, res) => {
         if (messageType === 'txt') {
             content = messageBody.msg;
         } else if (messageType === 'custom') {
-            content = getValueByPath(messageBody.customExts?.[0] || {}, policies.fields?.[0] || '');
+            content = getValueByField(messageBody.customExts?.[0] || {}, policies.customField || '');
         }
         if (!content) {
             res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -58,7 +58,7 @@ WebApp.handlers.use('/webhook/moderate', jsonParser, async (req, res) => {
                 response.payload = payload;
             } else if (messageBody.type === 'custom' && action === 'Replace With Asterisks (*)') {
                 const result = await replaceBlockedWords(content);
-                setValueByPath(messageBody.customExts?.[0] || {}, policies.fields?.[0] || '', result.updatedText);
+                setValueByField(messageBody.customExts?.[0] || {}, policies.customField || '', result.updatedText);
                 response.payload = payload;
             }
         }

--- a/server/webhook/webhook.ts
+++ b/server/webhook/webhook.ts
@@ -59,6 +59,7 @@ WebApp.handlers.use('/webhook/moderate', jsonParser, async (req, res) => {
             } else if (messageBody.type === 'custom' && action === 'Replace With Asterisks (*)') {
                 const result = await replaceBlockedWords(content);
                 setValueByField(messageBody.customExts?.[0] || {}, policies.customField || '', result.updatedText);
+                setValueByField(messageBody["v2:customExts"] || {}, policies.customField || '', result.updatedText);
                 response.payload = payload;
             }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,6 @@
     "esModuleInterop": true,
     "preserveSymlinks": true
   },
-  "include": ["**/*.ts"],
   "exclude": [
     "./.meteor/**",
     "./packages/**"


### PR DESCRIPTION
### Description

* Support `v2:customExts` in webhook custom messages
* Adjust policy action column width
* Make the `aside` element full height
* Rename `field` to `customField` in policies
* Remove unused `include` from `tsconfig.json`
* Add `.meteor/versions` for consistent dependency tracking

### How to Test

* Send a custom message containing `v2:customExts`, check that the webhook handles it correctly
* Open the policies page and check that layout and styles look correct
